### PR TITLE
Trigger fathom story event

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,7 +33,7 @@ function MyApp({ Component, pageProps }) {
 
   useEffect(() => {
     Fathom.load('XNKNPYHV', {
-      includedDomains: ['staging.mycovidstory.ca', 'www.mycovidstory.ca'],
+      includedDomains: ['www.mycovidstory.ca'],
     })
 
     function onRouteChangeComplete() {

--- a/pages/thanks.tsx
+++ b/pages/thanks.tsx
@@ -1,6 +1,12 @@
+import { useEffect } from 'react'
 import { Center, Heading, Text, Container, Button, VStack, Icon } from '@chakra-ui/react'
 
 export default function Thanks() {
+  // Triggers a Story goal event on Fathom
+  useEffect(() => {
+    window?.fathom?.trackGoal('RT0FH11Y', 0)
+  }, [])
+
   return (
     <Container pt="32">
       <Center>


### PR DESCRIPTION
Adds a simple call to our analytics to count towards a story goal. Because, why not?