### PR TITLE
Do not cite stories with category "other" as from "Resident"

### DIFF
--- a/components/stories/StoryDetail.tsx
+++ b/components/stories/StoryDetail.tsx
@@ -1,7 +1,14 @@
 import { Box, IconButton, Flex, Heading, Stack, Text } from '@chakra-ui/react'
 import { CloseIcon } from '@chakra-ui/icons'
 import { Story } from '@prisma/client'
-import { storyCategory, storyImage, storyName, storyDate, storyParagraphs } from './model'
+import {
+  categoryLabel,
+  storyCategoryLabel,
+  storyImage,
+  storyName,
+  storyDate,
+  storyParagraphs,
+} from './model'
 
 interface Props {
   story: Story
@@ -28,6 +35,7 @@ export default function StoryDetail({ story, onClose }: Props) {
           <Flex>
             <Heading
               as="h2"
+              visibility={categoryLabel[story.category] ? 'visible' : 'hidden'}
               py={1}
               px={2}
               border="2px"
@@ -36,7 +44,7 @@ export default function StoryDetail({ story, onClose }: Props) {
               fontSize="md"
               fontWeight={600}
             >
-              {storyCategory(story)}
+              {storyCategoryLabel(story)}
             </Heading>
           </Flex>
           <Heading

--- a/components/stories/model.ts
+++ b/components/stories/model.ts
@@ -1,23 +1,16 @@
 import { Story } from '@prisma/client'
 
-export function storyCategory({ category }: Story) {
-  switch (category) {
-    case 'concerned-citizen':
-      return 'Concerned Citizen'
-    case 'essential-worker':
-      return 'Essential Worker'
-    case 'healthcare-provider':
-      return 'Healthcare Provider'
-    case 'educator':
-      return 'Educator'
-    case 'small-business-owner':
-      return 'Small Business Owner'
-    case 'patient-family-member':
-      return 'Patient or Family Member'
-    case 'other':
-    default:
-      return 'Resident'
-  }
+export const categoryLabel = {
+  'concerned-citizen': 'Concerned Citizen',
+  'essential-worker': 'Essential Worker',
+  'healthcare-provider': 'Healthcare Provider',
+  educator: 'Educator',
+  'small-business-owner': 'Small Business Owner',
+  'patient-family-member': 'Patient or Family Member',
+}
+
+export function storyCategoryLabel({ category }: Story) {
+  return categoryLabel[category] || 'Other'
 }
 
 export function storyImage({ category }: Story) {
@@ -39,9 +32,10 @@ export function storyName({ displayName }: Story) {
   return displayName || 'Anonymous'
 }
 
-export function storyCite(story: Story) {
-  const { displayName, postal } = story
-  return displayName ? `${displayName} from ${postal}` : `${storyCategory(story)} from ${postal}`
+export function storyCite({ displayName, category, postal }: Story) {
+  if (displayName) return `${displayName} from ${postal}`
+  const cl = categoryLabel[category]
+  return cl ? `${cl} from ${postal}` : `From ${postal}`
 }
 
 export function storyDate({ createdAt }: Story) {


### PR DESCRIPTION
Revisits the decision to show stories with category "other" in the feed as "Resident from <postal code>". Resident is too similar to Concerned Citizen, so we're just going to show no category for now, pending revisiting the categories.

I also realized that a case statement was a silly way to do a map lookup. 🧐