### PR TITLE
Make home page responsive

### DIFF
--- a/components/common/ContentBox.tsx
+++ b/components/common/ContentBox.tsx
@@ -1,0 +1,24 @@
+import { useTheme, Box } from '@chakra-ui/react'
+
+export const RESPONSIVE_PADDING = [4, null, 8]
+
+interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  py?: any
+  children?: React.ReactNode
+  [x: string]: unknown
+}
+
+export default function ContentBox({ py, children, ...props }: Props) {
+  const { breakpoints } = useTheme()
+
+  if (py === true) {
+    py = RESPONSIVE_PADDING
+  }
+
+  return (
+    <Box maxW={breakpoints.lg} m="auto" px={RESPONSIVE_PADDING} py={py} {...props}>
+      {children}
+    </Box>
+  )
+}

--- a/components/stories/StoryFeed.tsx
+++ b/components/stories/StoryFeed.tsx
@@ -1,16 +1,27 @@
 import NextLink from 'next/link'
-import { Box, Heading, Link, Stack, Text } from '@chakra-ui/react'
+import { Box, Heading, Link, SimpleGrid } from '@chakra-ui/react'
 import { storyImage, storyCite } from './model'
+import ContentBox from '../common/ContentBox'
 
 export default function StoryFeed({ stories }) {
   return (
     <Box>
       <FeedHeader />
-      <Stack as="main" py={6} px={4} spacing={6}>
-        {stories.map((story) => (
-          <StorySummary key={story.id} story={story} />
-        ))}
-      </Stack>
+      <ContentBox py>
+        <Heading as="h2" mb={[6, null, 8]} color="primary.100">
+          Stories
+        </Heading>
+        <SimpleGrid
+          as="main"
+          columns={[1, null, 2]}
+          spacingY={[6, null, 8]}
+          spacingX={[6, null, 10, 16]}
+        >
+          {stories.map((story) => (
+            <StorySummary key={story.id} story={story} />
+          ))}
+        </SimpleGrid>
+      </ContentBox>
     </Box>
   )
 }
@@ -23,10 +34,12 @@ function FeedHeader() {
       bgPosition="center 55%"
       color="white"
     >
-      <Box pt={8} pb={10} px={4} bg="rgba(0, 0, 0, 0.5)">
-        <Heading as="h1" fontSize="2xl" fontWeight={300}>
-          If our leaders won’t listen to the numbers, they must face our stories.
-        </Heading>
+      <Box bg="rgba(0, 0, 0, 0.5)">
+        <ContentBox pt={[8, null, 14]} pb={[10, null, 32]}>
+          <Heading as="h1" fontSize={['2xl', null, '4xl', '5xl']} fontWeight={300}>
+            If our leaders won’t listen to the numbers, they must face our stories.
+          </Heading>
+        </ContentBox>
       </Box>
     </Box>
   )
@@ -46,27 +59,27 @@ function StorySummary({ story }) {
             bgPosition="center"
             color="white"
           >
-            <Box py={4} px={6} borderRadius="8px" bg="rgba(0, 0, 0, 0.5)">
-              <Heading
-                as="h2"
-                mb={4}
-                minH="6rem"
-                fontSize="2xl"
-                fontWeight={600}
-                fontStyle="italic"
-                noOfLines={3}
-                _before={{ content: `"“"` }}
-                _after={{ content: `"”"` }}
-              >
-                {story.title}
-              </Heading>
-              <Text>{storyCite(story)}</Text>
+            <Box pt={4} pb={4} px={[6, null, 7]} borderRadius="8px" bg="rgba(0, 0, 0, 0.5)">
+              <Box minH="6em" mt={[0, null, 4, 6]} mb={[4, null, 8, 12]}>
+                <Heading
+                  as="h3"
+                  fontSize="2xl"
+                  fontWeight={600}
+                  fontStyle="italic"
+                  noOfLines={3}
+                  _before={{ content: `"“"` }}
+                  _after={{ content: `"”"` }}
+                >
+                  {story.title}
+                </Heading>
+              </Box>
+              <Box lineHeight={1.2}>{storyCite(story)}</Box>
             </Box>
           </Box>
 
-          <Heading as="h3" mt={2} color="#333333" fontSize="md" fontWeight={700}>
+          <Box mt={2} color="#333333" fontSize="md" fontWeight={700} lineHeight={1.2}>
             Read Story
-          </Heading>
+          </Box>
         </Link>
       </NextLink>
     </Box>


### PR DESCRIPTION
This implements issue #75, providing a desktop design for the story feed on the home page.

In terms of breakpoints, `base` & `small` cover phones, Curtis's desktop design is `lg`, and `md` is a slight modification of it that reduces the font size over the hero image and removes a bit of whitespace between the columns in order to fit on a tablet-sized screen.

I've also introduced a `ContentBox` common component, which can be put around anything else to make it centre beyond a standard maximum width and to add standard responsive padding. `RESPONSIVE_PADDING` is also exported so that other components can use it directly. I'll have a follow-on PR shortly that applies this to most of the rest of the site.