### PR TITLE
Responsive story detail page

### DIFF
--- a/components/common/Label.tsx
+++ b/components/common/Label.tsx
@@ -1,0 +1,28 @@
+import { Box } from '@chakra-ui/react'
+
+interface Props {
+  color?: string
+  children?: React.ReactNode
+  [x: string]: unknown
+}
+
+export default function Label({ children, ...props }: Props) {
+  const color = props.color || 'white'
+
+  return (
+    <Box
+      py={1}
+      px={2}
+      border="1px"
+      borderRadius="4px"
+      borderColor={color}
+      color={color}
+      fontSize="md"
+      fontWeight={600}
+      lineHeight={1.2}
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/components/common/Label.tsx
+++ b/components/common/Label.tsx
@@ -1,12 +1,6 @@
-import { Box } from '@chakra-ui/react'
+import { Box, BoxProps } from '@chakra-ui/react'
 
-interface Props {
-  color?: string
-  children?: React.ReactNode
-  [x: string]: unknown
-}
-
-export default function Label({ children, ...props }: Props) {
+export default function Label({ children, ...props }: BoxProps) {
   const color = props.color || 'white'
 
   return (

--- a/components/stories/StoryDetail.tsx
+++ b/components/stories/StoryDetail.tsx
@@ -1,14 +1,8 @@
 import { Box, IconButton, Flex, Heading, Stack, Text } from '@chakra-ui/react'
 import { CloseIcon } from '@chakra-ui/icons'
 import { Story } from '@prisma/client'
-import {
-  categoryLabel,
-  storyCategoryLabel,
-  storyImage,
-  storyName,
-  storyDate,
-  storyParagraphs,
-} from './model'
+import { storyCategoryLabel, storyImage, storyName, storyDate, storyParagraphs } from './model'
+import ContentBox from '../common/ContentBox'
 
 interface Props {
   story: Story
@@ -19,56 +13,54 @@ export default function StoryDetail({ story, onClose }: Props) {
   return (
     <Box>
       <Box bgImage={storyImage(story)} bgSize="cover" bgPosition="center" color="white">
-        <Box pos="relative" p={4} bg="rgba(0, 0, 0, 0.5)">
-          <IconButton
-            pos="absolute"
-            top={4}
-            right={4}
-            size="md"
-            py={2}
-            variant="link"
-            colorScheme="white"
-            aria-label="Close"
-            icon={<CloseIcon />}
-            onClick={onClose}
-          />
-          <Flex>
+        <Box bg="rgba(0, 0, 0, 0.5)">
+          <ContentBox py>
+            <Flex justifyContent="space-between">
+              <Box
+                py={1}
+                px={2}
+                border="2px"
+                borderColor="gray.200"
+                borderRadius="4px"
+                fontSize="md"
+                fontWeight={600}
+                lineHeight={1.2}
+              >
+                {storyCategoryLabel(story)}
+              </Box>
+              <IconButton
+                size="md"
+                mr={-2}
+                py={2}
+                variant="link"
+                colorScheme="white"
+                aria-label="Close"
+                icon={<CloseIcon />}
+                onClick={onClose}
+              />
+            </Flex>
             <Heading
-              as="h2"
-              visibility={categoryLabel[story.category] ? 'visible' : 'hidden'}
-              py={1}
-              px={2}
-              border="2px"
-              borderColor="gray.200"
-              borderRadius="4px"
-              fontSize="md"
+              as="h1"
+              my={[5, null, 10]}
+              fontSize={['2xl', null, '4xl', '5xl']}
               fontWeight={600}
+              fontStyle="italic"
+              _before={{ content: `"“"` }}
+              _after={{ content: `"”"` }}
             >
-              {storyCategoryLabel(story)}
+              {story.title}
             </Heading>
-          </Flex>
-          <Heading
-            as="h1"
-            mt={5}
-            mb={4}
-            fontSize="2xl"
-            fontWeight={600}
-            fontStyle="italic"
-            _before={{ content: `"“"` }}
-            _after={{ content: `"”"` }}
-          >
-            {story.title}
-          </Heading>
-          <Heading as="h3" fontSize="md" fontWeight={600}>
-            From {story.postal}
-          </Heading>
+            <Box fontSize="md" fontWeight={600} lineHeight={1.2}>
+              From {story.postal}
+            </Box>
+          </ContentBox>
         </Box>
       </Box>
-      <Box m={4}>
-        <Heading as="h3" mb={2} fontSize="md" fontWeight={700}>
+      <ContentBox py>
+        <Heading as="h2" mb={3} fontSize="md" fontWeight={700}>
           {storyDate(story)}
         </Heading>
-        <Heading as="h3" mb={4} fontSize="md" fontWeight={700}>
+        <Heading as="h2" mb={4} fontSize="md" fontWeight={700}>
           {storyName(story)}
         </Heading>
         <Stack spacing={2}>
@@ -76,7 +68,7 @@ export default function StoryDetail({ story, onClose }: Props) {
             <Text key={i}>{p}</Text>
           ))}
         </Stack>
-      </Box>
+      </ContentBox>
     </Box>
   )
 }

--- a/components/stories/StoryDetail.tsx
+++ b/components/stories/StoryDetail.tsx
@@ -3,6 +3,7 @@ import { CloseIcon } from '@chakra-ui/icons'
 import { Story } from '@prisma/client'
 import { storyCategoryLabel, storyImage, storyName, storyDate, storyParagraphs } from './model'
 import ContentBox from '../common/ContentBox'
+import Label from '../common/Label'
 
 interface Props {
   story: Story
@@ -16,18 +17,7 @@ export default function StoryDetail({ story, onClose }: Props) {
         <Box bg="rgba(0, 0, 0, 0.5)">
           <ContentBox py>
             <Flex justifyContent="space-between">
-              <Box
-                py={1}
-                px={2}
-                border="2px"
-                borderColor="gray.200"
-                borderRadius="4px"
-                fontSize="md"
-                fontWeight={600}
-                lineHeight={1.2}
-              >
-                {storyCategoryLabel(story)}
-              </Box>
+              <Label>{storyCategoryLabel(story)}</Label>
               <IconButton
                 size="md"
                 mr={-2}

--- a/components/stories/StoryFeed.tsx
+++ b/components/stories/StoryFeed.tsx
@@ -1,7 +1,8 @@
 import NextLink from 'next/link'
-import { Box, Heading, Link, SimpleGrid } from '@chakra-ui/react'
-import { storyImage, storyCite } from './model'
+import { Box, Flex, Heading, Link, SimpleGrid } from '@chakra-ui/react'
+import { storyCategoryLabel, storyImage, storyCite } from './model'
 import ContentBox from '../common/ContentBox'
+import Label from '../common/Label'
 
 export default function StoryFeed({ stories }) {
   return (
@@ -59,8 +60,11 @@ function StorySummary({ story }) {
             bgPosition="center"
             color="white"
           >
-            <Box pt={4} pb={4} px={[6, null, 7]} borderRadius="8px" bg="rgba(0, 0, 0, 0.5)">
-              <Box minH="6em" mt={[0, null, 4, 6]} mb={[4, null, 8, 12]}>
+            <Box p={[4, null, null, 6]} borderRadius="8px" bg="rgba(0, 0, 0, 0.5)">
+              <Flex>
+                <Label>{storyCategoryLabel(story)}</Label>
+              </Flex>
+              <Box minH="6em" my={[4, null, null, 6]}>
                 <Heading
                   as="h3"
                   fontSize="2xl"

--- a/components/stories/model.ts
+++ b/components/stories/model.ts
@@ -32,10 +32,8 @@ export function storyName({ displayName }: Story) {
   return displayName || 'Anonymous'
 }
 
-export function storyCite({ displayName, category, postal }: Story) {
-  if (displayName) return `${displayName} from ${postal}`
-  const cl = categoryLabel[category]
-  return cl ? `${cl} from ${postal}` : `From ${postal}`
+export function storyCite({ displayName, postal }: Story) {
+  return displayName ? `${displayName} from ${postal}` : `From ${postal}`
 }
 
 export function storyDate({ createdAt }: Story) {


### PR DESCRIPTION
This makes the story detail page responsive, as per @curtis-vdg's design.

It also implements the latest design changes in the story feed, factoring out a new common `Label` component and using it to show the category on each story in the feed. @silent1mezzo you can also reuse this same `Label` component in PR #99, just passing different `color`, `bg`, and children to it.