### PR TITLE
Feat: custom 404

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,7 @@ module.exports = {
             allowConciseArrowFunctionExpressionsStartingWithVoid: true,
           },
         ],
-        'prettier/prettier': ['error', {}, { usePrettierrc: true }], // Includes .prettierrc.js rules
+        'prettier/prettier': ['error', { endOfLine: 'auto' }, { usePrettierrc: true }], // Includes .prettierrc.js rules
       },
     },
   ],

--- a/components/common/MenuItem.tsx
+++ b/components/common/MenuItem.tsx
@@ -1,11 +1,14 @@
 import { Link, Text } from '@chakra-ui/react'
+import NextLink from 'next/link'
 
 export default function MenuItem({ children, to = '/', externalLink = false, ...rest }) {
   return (
-    <Link href={to} isExternal={externalLink}>
-      <Text display="block" {...rest}>
-        {children}
-      </Text>
-    </Link>
+    <NextLink href={to} passHref>
+      <Link href={to} isExternal={externalLink}>
+        <Text display="block" {...rest}>
+          {children}
+        </Text>
+      </Link>
+    </NextLink>
   )
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -5,13 +5,13 @@ interface ResponseErrorOptions {
   allowed?: string[]
 }
 
-interface ResponseError extends ResponseErrorOptions {
+export interface ResponseError extends ResponseErrorOptions {
   message: string
   status: number
 }
 
-class ResponseError extends Error {
-  constructor(message, status, options: ResponseErrorOptions = {}) {
+export class ResponseError extends Error {
+  constructor(message: string, status: number, options: ResponseErrorOptions = {}) {
     super(message)
     Error.captureStackTrace(this, ResponseError)
     this.status = status

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint \"*/**/*.{js,ts,tsx}\" --quiet --fix",
     "format": "prettier --write \"{,!(node_modules)/**/}*.{js,jsx}\"",
     "prepare": "husky install",
-    "ts-node": "ts-node --compiler-options '{\"module\":\"CommonJS\"}'",
+    "ts-node": "ts-node --project=tsconfig.seed.json",
     "vercel-build": "prisma migrate deploy && next build",
     "prisma:generate": "prisma generate",
     "gen:theme-typings": "chakra-cli tokens theme/index.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "type-check": "tsc --project tsconfig.json --pretty --noEmit",
-    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
+    "lint": "eslint \"*/**/*.{js,ts,tsx}\" --quiet --fix",
     "format": "prettier --write \"{,!(node_modules)/**/}*.{js,jsx}\"",
     "prepare": "husky install",
     "ts-node": "ts-node --compiler-options '{\"module\":\"CommonJS\"}'",

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,0 +1,30 @@
+import { chakra, Flex, Heading, Text } from '@chakra-ui/react'
+
+interface ErrorPageProps {
+  code: number
+  message: string
+}
+
+/**
+ * A reusable error page: it automatically handles Next errors, but it can also be used with a custom status code and message.
+ * @param code the status code referred to the error, defaults to `404` for Next automatic error handling.
+ * @param message the message to display with the error, defaults to "Not found" for Next automatic error handling.
+ */
+export default function ErrorPage({
+  code = 404,
+  message = 'Not found',
+}: ErrorPageProps): JSX.Element {
+  return (
+    <Flex flexWrap="wrap" justifyContent="center" alignItems="center" height="100%">
+      <Flex flexWrap="wrap" justifyContent="center">
+        <Heading>Ooops... there was an error!</Heading>
+
+        <chakra.div flexBasis="100%"></chakra.div>
+
+        <Text>
+          Status code: <code>{code}</code>, message: &quot;{message}&quot;
+        </Text>
+      </Flex>
+    </Flex>
+  )
+}

--- a/tsconfig.seed.json
+++ b/tsconfig.seed.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This pull request is actually a set of small commits I made when setting up the dev environment and a slightly bigger commit for the custom error page.

### Commits explained:
- On windows, with eslint's endOfLine rule activated, VSCode kept flashing with red squiggly lines, so I set it to `auto`, which should adapt to whatever end of line is currently used. The command `npm run lint` was broken because of the way Windows reads paths. Should be working good now, tested on both Windows and WSL (Ubuntu distro).
- While visiting the website for the first time, I encountered a UX issue with the links in the top navbar, which instead of being NextJS links were Chakra links. I wrapped the Chakra `MenuItem` with Next's `Link` component.
- Seeding was broken on Windows, so instead of passing the compiler options via a Node script I added a custom `tsconfig.seed.json` which is used when seeding the db.
- Added the feature requested in issue #103 of a custom 404 page. Following a broken path now returns this page, along with visiting a broken story path.

### Points to work on
- Styling: the 404 page I added is very basic in terms of styling, it might be a good idea to add some illustrations or similar (https://undraw.co?).

Would close #103.