### PR TITLE
Hide Other label again on story feed and detail pages

### DIFF
--- a/components/stories/StoryDetail.tsx
+++ b/components/stories/StoryDetail.tsx
@@ -1,7 +1,14 @@
 import { Box, IconButton, Flex, Heading, Stack, Text } from '@chakra-ui/react'
 import { CloseIcon } from '@chakra-ui/icons'
 import { Story } from '@prisma/client'
-import { storyCategoryLabel, storyImage, storyName, storyDate, storyParagraphs } from './model'
+import {
+  categoryLabel,
+  storyCategoryLabel,
+  storyImage,
+  storyName,
+  storyDate,
+  storyParagraphs,
+} from './model'
 import ContentBox from '../common/ContentBox'
 import Label from '../common/Label'
 
@@ -17,7 +24,9 @@ export default function StoryDetail({ story, onClose }: Props) {
         <Box bg="rgba(0, 0, 0, 0.5)">
           <ContentBox py>
             <Flex justifyContent="space-between">
-              <Label>{storyCategoryLabel(story)}</Label>
+              <Label visibility={categoryLabel[story.category] ? 'visible' : 'hidden'}>
+                {storyCategoryLabel(story)}
+              </Label>
               <IconButton
                 size="md"
                 mr={-2}

--- a/components/stories/StoryFeed.tsx
+++ b/components/stories/StoryFeed.tsx
@@ -1,6 +1,6 @@
 import NextLink from 'next/link'
 import { Box, Flex, Heading, Link, SimpleGrid } from '@chakra-ui/react'
-import { storyCategoryLabel, storyImage, storyCite } from './model'
+import { categoryLabel, storyCategoryLabel, storyImage, storyCite } from './model'
 import ContentBox from '../common/ContentBox'
 import Label from '../common/Label'
 
@@ -62,7 +62,9 @@ function StorySummary({ story }) {
           >
             <Box p={[4, null, null, 6]} borderRadius="8px" bg="rgba(0, 0, 0, 0.5)">
               <Flex>
-                <Label>{storyCategoryLabel(story)}</Label>
+                <Label visibility={categoryLabel[story.category] ? 'visible' : 'hidden'}>
+                  {storyCategoryLabel(story)}
+                </Label>
               </Flex>
               <Box minH="6em" my={[4, null, null, 6]}>
                 <Heading


### PR DESCRIPTION
This restores the hiding of Other labels, which I accidentally lost in PR #108. This must be the most changed/reverted/changed thing in this project. Oops.