### PR TITLE
Use NEXT_PUBIC_BASE_URL to compute Location header in POST response

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,10 @@
+# Development Environment
+#
+# Next.js automatically loads these environment variables when the development server starts.
+# This file is committed to Git, so it must not contain any secrets. Put secrets in .env.local, instead.
+#
+# Prisma uses DATABASE_URL to connect to the database: https://pris.ly/d/prisma-schema#using-environment-variables
+# It supports native the PostgreSQL connection string format: https://pris.ly/d/connection-strings
+
+DATABASE_URL="postgresql://postgres:mycovidstory@0.0.0.0:5432/postgres"
+NEXT_PUBLIC_VERCEL_URL=http://localhost:3000

--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,4 @@
 # It supports native the PostgreSQL connection string format: https://pris.ly/d/connection-strings
 
 DATABASE_URL="postgresql://postgres:mycovidstory@0.0.0.0:5432/postgres"
-NEXT_PUBLIC_VERCEL_URL=http://localhost:3000
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/.env.template
+++ b/.env.template
@@ -1,9 +1,0 @@
-# Rename this file to just .env (remove .template)
-
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL and SQLite.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-DATABASE_URL="postgresql://postgres:mycovidstory@0.0.0.0:5432/postgres"

--- a/README.md
+++ b/README.md
@@ -10,15 +10,23 @@ Our stack / architecture is:
 
 ## Contributing
 
-1. Clone this repo
-2. Install dependencies with `npm i`
-3. Rename `.env.template` to `.env`
-4. Get a local postgres db running - Docker is probably easiest, but local postgres would also work
-5. With Docker installed, run `docker run --name my-covid-story-dev -p 5432:5432 -e POSTGRES_PASSWORD=mycovidstory -d postgres:12.6-alpine` (this will match the DB URL string in .env)
-6. Run `npx prisma migrate dev --name init` to apply migrations in `prisma/migrations`.
-7. Run `npx prisma db seed --preview-feature` to see test data from `prisma/seed.ts`.
-8. Run `npm run dev` to start the app locally.
-9. You can use `/api/stories` to create new stories.
+1. Clone this repo.
+
+1. Install dependencies with `npm i`.
+
+1. Get a local PostgreSQL DB running. The easiest way is with Docker:
+
+   ```
+   docker run --name my-covid-story-dev -p 5432:5432 -e POSTGRES_PASSWORD=mycovidstory -d postgres:12.6-alpine
+   ```
+
+   This will match the `DATABASE_URL` specified in `.env.development`.
+
+1. Run `npx prisma migrate dev --name init` to apply migrations in `prisma/migrations`.
+
+1. Run `npx prisma db seed --preview-feature` to see test data from `prisma/seed.ts`.
+
+1. Run `npm run dev` to start the application in the Next.js development server, and open it in the browser at http://localhost:3000
 
 ---
 

--- a/pages/api/stories/index.ts
+++ b/pages/api/stories/index.ts
@@ -10,7 +10,7 @@ export default function handle(req: NextApiRequest, res: NextApiResponse) {
     case 'POST':
       return stories.add(req.body).then(
         (result) => {
-          res.setHeader('Location', `${process.env.NEXT_PUBLIC_VERCEL_URL}${req.url}/${result.id}`)
+          res.setHeader('Location', `${process.env.NEXT_PUBLIC_BASE_URL}${req.url}/${result.id}`)
           res.status(201).json(result)
         },
         (err) => sendError(res, err)

--- a/pages/api/stories/index.ts
+++ b/pages/api/stories/index.ts
@@ -2,8 +2,6 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { sendError, methodNotAllowed } from '../../../lib/errors'
 import * as stories from '../../../lib/api/stories'
 
-const baseUrl = 'https://mycovidstory.ca'
-
 // GET, POST /api/stories
 export default function handle(req: NextApiRequest, res: NextApiResponse) {
   switch (req.method) {
@@ -12,7 +10,7 @@ export default function handle(req: NextApiRequest, res: NextApiResponse) {
     case 'POST':
       return stories.add(req.body).then(
         (result) => {
-          res.setHeader('Location', `${baseUrl}${req.url}/${result.id}`)
+          res.setHeader('Location', `${process.env.NEXT_PUBLIC_VERCEL_URL}${req.url}/${result.id}`)
           res.status(201).json(result)
         },
         (err) => sendError(res, err)


### PR DESCRIPTION
The intent of this PR is just to try using `process.env.NEXT_PUBIC_VERCEL_URL` in the `/api/stories` handler, instead of the hard-coded base URL we had before. If this works in preview and prod, we can use it in place of `NEXT_PUBLIC_BASE_URL` and stop setting that environment variable.

For dev, I had to set the environment variable manually, and as I was reading about Next.js environment variables, I found that we can use a `.env.development` file for any non-secret, dev-only values. This approach removes a step for a new developer (copying `.env.template` to `.env`) and allows us to add new values that will be picked up by existing developers automatically.
So, I renamed the current `.env.template` file and updated the comments and the README accordingly.
