### PR TITLE
Decrease time to revalidate index page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,7 @@ export async function getStaticProps() {
   const stories = await list()
   return {
     props: { stories },
-    revalidate: 600, // 10 minutes
+    revalidate: 60, // 1 minutes
   }
 }
 


### PR DESCRIPTION
The DB is holding steady. This allows moderated stories to show up 9 minutes faster