### PR TITLE
Add better metatags

### DIFF
--- a/components/admin/nav.tsx
+++ b/components/admin/nav.tsx
@@ -11,7 +11,7 @@ import {
 import { CloseIcon, HamburgerIcon } from '@chakra-ui/icons'
 
 import { signIn, signOut } from 'next-auth/client'
-import ContentBox from '../../components/common/ContentBox'
+import ContentBox from '../common/ContentBox'
 import { Session } from 'next-auth'
 
 const Links = [

--- a/components/common/HeadTags.tsx
+++ b/components/common/HeadTags.tsx
@@ -1,0 +1,63 @@
+import Head from 'next/head'
+
+const defaultTitle = 'The Stories of COVID-19 in Ontario'
+const defaultDescription =
+  "Ontario is in a humanitarian crisis. If our leaders won't listen to the numbers, they must face our stories."
+const defaultPreviewImage = `img/landingpage-v2.jpg`
+
+interface HeadTagsProps {
+  title?: string
+  description?: string
+  previewImage?: string
+  children?: React.ReactNode
+}
+
+const TITLE_SUFFIX = 'MyCOVIDStory.ca'
+const DESCRIPTION_LENGTH = 170
+
+export default function HeadTags({
+  children,
+  title = defaultTitle,
+  description = defaultDescription,
+  previewImage = defaultPreviewImage,
+}: HeadTagsProps) {
+  const generatedTitle = generateTitle(title, TITLE_SUFFIX)
+  const generatedDescription = generateDescription(description, DESCRIPTION_LENGTH)
+  const generatedPreviewImage = generatePreviewImageUrl(previewImage)
+
+  return (
+    <Head>
+      <title key="title">{generatedTitle}</title>
+      <meta key="description" name="description" content={generatedDescription} />
+
+      <meta key="og:title" property="og:title" content={generatedTitle} />
+      <meta key="og:description" property="og:description" content={generatedDescription} />
+      <meta key="og:image" property="og:image" content={generatedPreviewImage} />
+
+      <meta key="twitter:title" name="twitter:title" content={generatedTitle} />
+      <meta key="twitter:description" name="twitter:description" content={generatedDescription} />
+      <meta key="twitter:image" name="twitter:image" content={generatedPreviewImage} />
+      {children}
+    </Head>
+  )
+}
+
+// Limits the title string and appends our default suffix.
+function generateTitle(title: string, suffix: string): string {
+  if (title.length > 50) {
+    return `${title.slice(0, 50)} | ${suffix}`
+  } else {
+    return `${title} | ${suffix}`
+  }
+}
+
+// Limits description text to maxLength
+function generateDescription(description: string, maxLength: number): string {
+  return description.slice(0, maxLength)
+}
+
+function generatePreviewImageUrl(path: string): string {
+  // strip leading slash
+  const cleanPath = path.replace(/^\/+/, '')
+  return `${process.env.BASE_URL}/${cleanPath}`
+}

--- a/components/stories/StoryDetail.tsx
+++ b/components/stories/StoryDetail.tsx
@@ -24,7 +24,7 @@ interface StoryDetailProps {
 export default function StoryDetail({ story, onClose }: StoryDetailProps) {
   return (
     <Box>
-      <Box bgImage={storyImage(story)} bgSize="cover" bgPosition="center" color="white">
+      <Box bgImage={`url(${storyImage(story)})`} bgSize="cover" bgPosition="center" color="white">
         <Box bg="rgba(0, 0, 0, 0.5)">
           <ContentBox>
             <Flex justifyContent="space-between">

--- a/components/stories/StoryFeed.tsx
+++ b/components/stories/StoryFeed.tsx
@@ -37,7 +37,7 @@ function StorySummary({ story }: StorySummaryProps) {
         <Link _hover={{ textDecoration: 'none' }}>
           <Box
             borderRadius="8px"
-            bgImage={storyImage(story)}
+            bgImage={`url(${storyImage(story)})`}
             bgSize="cover"
             bgPosition="center"
             color="white"

--- a/components/stories/model.ts
+++ b/components/stories/model.ts
@@ -21,10 +21,10 @@ export function storyImage({ category }: Story): string {
     case 'educator':
     case 'small-business-owner':
     case 'patient-family-member':
-      return `url("/img/categories/${category}.jpg")`
+      return `/img/categories/${category}.jpg`
     case 'other':
     default:
-      return 'url("/img/categories/other.jpg")'
+      return '/img/categories/other.jpg'
   }
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,9 @@
+const baseUrl = process.env.VERCEL_ENV
+  ? `https://${process.env.VERCEL_URL}`
+  : `http://localhost:${process.env.PORT || '3000'}`
+
+console.log(`BASE_URL: ${baseUrl}`)
+
 module.exports = {
   future: {
     webpack5: true,
@@ -5,5 +11,8 @@ module.exports = {
   i18n: {
     locales: ['en-CA'],
     defaultLocale: 'en-CA',
+  },
+  env: {
+    BASE_URL: baseUrl,
   },
 }

--- a/pages/_admin/index.tsx
+++ b/pages/_admin/index.tsx
@@ -1,10 +1,11 @@
 import { Box, BoxProps, Button, Heading, Stack, Text } from '@chakra-ui/react'
 import { getSession, useSession } from 'next-auth/client'
 import Link from 'next/link'
+import HeadTags from '../../components/common/HeadTags'
 
 import prisma from '../../lib/prisma'
 import { Story } from '@prisma/client'
-import Nav from './nav'
+import Nav from '../../components/admin/nav'
 import ContentBox from '../../components/common/ContentBox'
 import { GetServerSidePropsContext } from 'next'
 
@@ -35,46 +36,51 @@ function StoryOptions({
   ...rest
 }: StoryOptionsProps) {
   return (
-    <Box mt={2} p={5} shadow="md" borderWidth="1px" {...rest}>
-      <Heading fontSize="xl">{title}</Heading>
-      <Text mt={4}>{content}</Text>
-      <Text mt={4} mb={4}>
-        {name || `Anonymous`} from {postal}
-      </Text>
-      <Text mt={4} mb={4}>
-        Contact: {email || twitter || phone ? `Yes` : 'No'}
-      </Text>
-      <Text mt={4} mb={4}>
-        ID: <Link href={`/story/${id}`}>{id}</Link>
-      </Text>
-      <Stack direction="row" spacing={4} align="center">
-        <Button
-          colorScheme="red"
-          variant="outline"
-          type="button"
-          data-id={id}
-          data-type={deleted ? 'undelete' : 'delete'}
-          onClick={(e) => {
-            if (
-              window.confirm(`Are you sure you want to ${deleted ? 'undelete' : 'delete'} this?`)
-            ) {
-              updateStory(e)
-            }
-          }}
-        >
-          {deleted ? 'Undelete' : 'Delete'}
-        </Button>
-        <Button
-          colorScheme="blue"
-          type="button"
-          data-id={id}
-          data-type={approved ? 'unapprove' : 'approve'}
-          onClick={updateStory}
-        >
-          {approved ? 'Unapprove' : 'Approve'}
-        </Button>
-      </Stack>
-    </Box>
+    <>
+      <HeadTags>
+        <meta name="robots" content="noindex" />
+      </HeadTags>
+      <Box mt={2} p={5} shadow="md" borderWidth="1px" {...rest}>
+        <Heading fontSize="xl">{title}</Heading>
+        <Text mt={4}>{content}</Text>
+        <Text mt={4} mb={4}>
+          {name || `Anonymous`} from {postal}
+        </Text>
+        <Text mt={4} mb={4}>
+          Contact: {email || twitter || phone ? `Yes` : 'No'}
+        </Text>
+        <Text mt={4} mb={4}>
+          ID: <Link href={`/story/${id}`}>{id}</Link>
+        </Text>
+        <Stack direction="row" spacing={4} align="center">
+          <Button
+            colorScheme="red"
+            variant="outline"
+            type="button"
+            data-id={id}
+            data-type={deleted ? 'undelete' : 'delete'}
+            onClick={(e) => {
+              if (
+                window.confirm(`Are you sure you want to ${deleted ? 'undelete' : 'delete'} this?`)
+              ) {
+                updateStory(e)
+              }
+            }}
+          >
+            {deleted ? 'Undelete' : 'Delete'}
+          </Button>
+          <Button
+            colorScheme="blue"
+            type="button"
+            data-id={id}
+            data-type={approved ? 'unapprove' : 'approve'}
+            onClick={updateStory}
+          >
+            {approved ? 'Unapprove' : 'Approve'}
+          </Button>
+        </Stack>
+      </Box>
+    </>
   )
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -60,10 +60,8 @@ function MyApp({ Component, pageProps }: MyAppProps) {
       <Head>
         <link key="favicon" rel="icon" href="/favicon.ico" />
         <meta key="twitter:card" name="twitter:card" content="summary_large_image" />
-        <meta key="twitter:url" name="twitter:url" content="https://www.mycovidstory.ca" />
         <meta name="twitter:creator" content="@MyCOVIDStory_CA" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://www.mycovidstory.ca" />
 
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,9 @@
 import '../styles/globals.css'
 import '@fontsource/inter/700.css'
 import '@fontsource/inter/400.css'
+
 import Head from 'next/head'
+import HeadTags from '../components/common/HeadTags'
 
 import { ReactElement, ReactNode, useEffect } from 'react'
 import { useRouter } from 'next/router'
@@ -19,11 +21,6 @@ Sentry.init({
   integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0,
 })
-
-const title = 'MyCovidStory.ca | The Stories of COVID-19 in Ontario'
-const description =
-  "Ontario is in a humanitarian crisis. If our leaders won't listen to the numbers, they must face our stories."
-const previewImage = 'https://www.mycovidstory.ca/img/landingpage-v2.jpg'
 
 type GetLayout = (page: ReactNode) => ReactElement
 type PageWithLayout = NextPage & {
@@ -61,18 +58,13 @@ function MyApp({ Component, pageProps }: MyAppProps) {
   return getLayout(
     <>
       <Head>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <link rel="icon" href="/favicon.ico" />
+        <link key="favicon" rel="icon" href="/favicon.ico" />
+        <meta key="twitter:card" name="twitter:card" content="summary_large_image" />
+        <meta key="twitter:url" name="twitter:url" content="https://www.mycovidstory.ca" />
+        <meta name="twitter:creator" content="@MyCOVIDStory_CA" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://www.mycovidstory.ca" />
 
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={description} />
-        <meta property="og:image" content={previewImage} />
-
-        <meta name="twitter:title" content={title} />
-        <meta name="twitter:description" content={description} />
-        <meta name="twitter:image" content={previewImage} />
-        <meta name="twitter:card" content="summary_large_image" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
@@ -83,6 +75,7 @@ function MyApp({ Component, pageProps }: MyAppProps) {
           {`{"@context": "https://schema.org", "@type": "Organization", "name": "MyCovidStory", "alternateName": "MyCovidStory.ca", "url": "https://MyCovidStory.ca", "logo": "", "sameAs": [ "https://www.facebook.com/MyCovidStoryCA", "https://twitter.com/MyCOVIDStory_CA", "https://www.instagram.com/MyCovidStory_CA/", "https://github.com/my-covid-story/www", "https://MyCovidStory.ca" ] }`}
         </script>
       </Head>
+      <HeadTags />
       <Component {...pageProps} />
     </>
   )

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,14 +1,14 @@
-import Head from 'next/head'
 import { Box, Heading, Stack, Text } from '@chakra-ui/react'
 import ContentBox from '../components/common/ContentBox'
+import HeadTags from '../components/common/HeadTags'
 
 export default function About() {
   return (
     <div>
-      <Head>
-        <title>About - My COVID Story</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+      <HeadTags
+        title="About The Project and Team"
+        description="Learn about why MyCovidStory.ca exists, how it began and meet the team of volunteers who came together in just 5 days to bring it to life."
+      />
       <ContentBox>
         <Heading as="h1" size="2xl" pb={6}>
           About

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,16 +1,15 @@
-import Head from 'next/head'
-
 import { Box, Heading, Link, Text } from '@chakra-ui/react'
 import styles from '../styles/FaqPage.module.css'
 import ContentBox from '../components/common/ContentBox'
+import HeadTags from '../components/common/HeadTags'
 
 export default function FAQ() {
   return (
     <div className={styles.faq}>
-      <Head>
-        <title>FAQ - My COVID Story</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+      <HeadTags
+        title="Frequently Asked Questions"
+        description="View our list of Frequently Asked Questions to learn more about how the site began, moderation guidelines and how we protect your privacy."
+      />
       <ContentBox>
         <Heading as="h1" size="2xl" pb={6}>
           Frequently Asked Questions

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import FloatingRibbon, { Button } from '../components/common/FloatingRibbon'
 import SiteLayout from '../layouts/Default'
 import { Story } from '@prisma/client'
 import { ReactNode } from 'react'
+import HeadTags from '../components/common/HeadTags'
 
 interface MainPageProps {
   stories: Story[]
@@ -14,6 +15,9 @@ interface MainPageProps {
 const MainPage = ({ stories }: MainPageProps) => {
   return (
     <>
+      <HeadTags>
+        <link rel="canonical" href="https://www.mycovidstory.ca" />
+      </HeadTags>
       <Box>
         <StoryFeed stories={stories} />
       </Box>

--- a/pages/new.tsx
+++ b/pages/new.tsx
@@ -2,21 +2,28 @@ import Link from 'next/link'
 import { Heading, Text } from '@chakra-ui/react'
 import ContentBox from '../components/common/ContentBox'
 import StoryForm from '../components/stories/StoryForm'
+import HeadTags from '../components/common/HeadTags'
 
 export default function CreateStory() {
   return (
-    <ContentBox>
-      <Heading as="h1" size="lg" pb={4}>
-        Share your COVID story
-      </Heading>
-      <Text>
-        Every number has a story. We believe in the power of storytelling to force government action
-        in Ontario. We value your privacy.
-      </Text>
-      <Text pt={4} pb={2} fontWeight="bold" color="#55099D">
-        <Link href="/faq">Read our FAQ</Link>
-      </Text>
-      <StoryForm />
-    </ContentBox>
+    <>
+      <HeadTags
+        title="Post your story"
+        description="Share your story of how COVID-19 has impacted you. If our leaders won't listen to the numbers, they must face our stories"
+      />
+      <ContentBox>
+        <Heading as="h1" size="lg" pb={4}>
+          Share your COVID story
+        </Heading>
+        <Text>
+          Every number has a story. We believe in the power of storytelling to force government
+          action in Ontario. We value your privacy.
+        </Text>
+        <Text pt={4} pb={2} fontWeight="bold" color="#55099D">
+          <Link href="/faq">Read our FAQ</Link>
+        </Text>
+        <StoryForm />
+      </ContentBox>
+    </>
   )
 }

--- a/pages/story/[id].tsx
+++ b/pages/story/[id].tsx
@@ -25,6 +25,8 @@ import { get, list } from '../../lib/api/stories'
 import generateSocial from '../../lib/social'
 import StoryDetail from '../../components/stories/StoryDetail'
 import FloatingRibbon, { Button } from '../../components/common/FloatingRibbon'
+import HeadTags from '../../components/common/HeadTags'
+import { storyImage } from '../../components/stories/model'
 
 const shareIconSize = 64
 const buttonStyle = { marginRight: '12px' }
@@ -50,6 +52,7 @@ export default function StoryPage({ story }: StoryPageProps) {
 
   return (
     <>
+      <HeadTags title={story.title} description={story.content} previewImage={storyImage(story)} />
       <Box>
         <StoryDetail story={story} onClose={handleClose} />
       </Box>

--- a/pages/story/[id].tsx
+++ b/pages/story/[id].tsx
@@ -46,7 +46,7 @@ export default function StoryPage({ story }: StoryPageProps) {
   }
 
   // Get Story details
-  const url = `${process.env.NEXT_PUBLIC_BASE_URL}/story/${story.id}`
+  const url = `${process.env.BASE_URL}/story/${story.id}`
   const description = generateSocial(story)
   const emailSubject = 'Help me amplify this story'
 

--- a/pages/thanks.tsx
+++ b/pages/thanks.tsx
@@ -1,6 +1,8 @@
 import { ReactNode, useEffect } from 'react'
 import { Button, Center, Container, Heading, Icon, Link, Text, VStack } from '@chakra-ui/react'
 
+import HeadTags from '../components/common/HeadTags'
+
 import BlankLayout from '../layouts/Blank'
 
 const Thanks = () => {
@@ -10,48 +12,54 @@ const Thanks = () => {
   }, [])
 
   return (
-    <Container pt="32">
-      <Center>
-        <Heading as="h1" size="lg" pb="8">
-          Thank you for your story
-        </Heading>
-      </Center>
-      <VStack spacing="12px" align="left">
-        <Text>
-          <strong>Thank you for submitting your story.</strong> We will amplify your story to engage
-          decision-makers and drive effective government policy with science-based practices that
-          will save lives.
-        </Text>
-        <Text>It may take 24-48 hours for your story to appear on the site.</Text>
-        <Text>
-          If you selected that you are willing to be contacted by the media, they may reach out to
-          you with the contact information that you provided.
-        </Text>
-        <Text>
-          {' '}
-          If you have any questions, reach out to{' '}
-          <a style={{ fontWeight: 'bold', color: '#55099D' }} href="mailto:info@mycovidstory.ca">
-            info@mycovidstory.ca
-          </a>
-          .
-        </Text>
-      </VStack>
-      <VStack pt="8" align="center" spacing={8}>
-        <Heading as="h2" size="md">
-          Spread the word
-        </Heading>
-        <Link href="https://twitter.com/MyCOVIDStory_CA" isExternal>
-          <Button color="white" leftIcon={<TwitterIcon />}>
-            Share @MyCOVIDStory_CA
-          </Button>
-        </Link>
-        <Link href="/">
-          <Button variant="outline" size="sm">
-            Return to Stories
-          </Button>
-        </Link>
-      </VStack>
-    </Container>
+    <>
+      <HeadTags
+        title="Thanks for sharing your story"
+        description="Thank you for sharing your story of the impact that COVID-19 has had on you. We'll be reviewing your submission soon."
+      />
+      <Container pt="32">
+        <Center>
+          <Heading as="h1" size="lg" pb="8">
+            Thank you for your story
+          </Heading>
+        </Center>
+        <VStack spacing="12px" align="left">
+          <Text>
+            <strong>Thank you for submitting your story.</strong> We will amplify your story to
+            engage decision-makers and drive effective government policy with science-based
+            practices that will save lives.
+          </Text>
+          <Text>It may take 24-48 hours for your story to appear on the site.</Text>
+          <Text>
+            If you selected that you are willing to be contacted by the media, they may reach out to
+            you with the contact information that you provided.
+          </Text>
+          <Text>
+            {' '}
+            If you have any questions, reach out to{' '}
+            <a style={{ fontWeight: 'bold', color: '#55099D' }} href="mailto:info@mycovidstory.ca">
+              info@mycovidstory.ca
+            </a>
+            .
+          </Text>
+        </VStack>
+        <VStack pt="8" align="center" spacing={8}>
+          <Heading as="h2" size="md">
+            Spread the word
+          </Heading>
+          <Link href="https://twitter.com/MyCOVIDStory_CA" isExternal>
+            <Button color="white" leftIcon={<TwitterIcon />}>
+              Share @MyCOVIDStory_CA
+            </Button>
+          </Link>
+          <Link href="/">
+            <Button variant="outline" size="sm">
+              Return to Stories
+            </Button>
+          </Link>
+        </VStack>
+      </Container>
+    </>
   )
 }
 


### PR DESCRIPTION
Adds metatags to help with SEO. Closes #78 

TODO

- [x] Create nice clean `BASE_URL` env var using `next.config.js`
- [x] Abstract the title slice logic into a little function
- [x] Test this to make sure SSR is working
- [x] Put favicon and other persistent tags back
- [x] ~Work with @natashabd to add in schema~ - handled in #125 