### PR TITLE
Feat: persist form data

### DIFF
--- a/components/common/PersistFormData.tsx
+++ b/components/common/PersistFormData.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { useFormikContext } from 'formik'
+import isEqual from 'react-fast-compare'
+import { useDebouncedCallback } from 'use-debounce'
+
+interface PersistFormDataProps {
+  name: string
+}
+
+export default function PersistFormData({ name }: PersistFormDataProps) {
+  const { values, setValues } = useFormikContext()
+  const previousValuesRef = useRef<unknown>()
+
+  const onSave = (values: unknown) => {
+    window.localStorage.setItem(name, JSON.stringify(values))
+  }
+
+  const debouncedOnSave = useDebouncedCallback(onSave, 300)
+
+  useEffect(() => {
+    const savedForm = window.localStorage.getItem(name)
+
+    if (savedForm) {
+      const parsedForm = JSON.parse(savedForm)
+
+      previousValuesRef.current = parsedForm
+      setValues(parsedForm)
+    }
+  }, [name, setValues])
+
+  useEffect(() => {
+    if (!isEqual(previousValuesRef.current, values)) {
+      debouncedOnSave(values)
+    }
+  })
+
+  useEffect(() => {
+    previousValuesRef.current = values
+  })
+
+  return null
+}

--- a/components/stories/StoryForm.tsx
+++ b/components/stories/StoryForm.tsx
@@ -55,6 +55,8 @@ const FIELD_PADDING = '4'
 const OPTIONAL_FIELD_PADDING = '2'
 
 export default function StoryForm() {
+  const formName = 'story-form'
+
   return (
     <Formik
       initialValues={initialValues}
@@ -82,6 +84,7 @@ export default function StoryForm() {
           })
           if (result.ok) {
             actions.setSubmitting(false)
+            window.localStorage.removeItem(formName)
             Router.push('/thanks')
           } else {
             console.error('something went wrong')
@@ -94,7 +97,7 @@ export default function StoryForm() {
     >
       {(props) => (
         <Form>
-          <PersistFormData name="story-form" />
+          <PersistFormData name={formName} />
 
           {/* Anonymous */}
           <Field name="anonymous">

--- a/components/stories/StoryForm.tsx
+++ b/components/stories/StoryForm.tsx
@@ -19,6 +19,7 @@ import { Field, Form, Formik } from 'formik'
 import Router from 'next/router'
 
 import storySchema, { STORY_WORD_LIMIT, TITLE_CHAR_LIMIT } from '../../lib/storySchema'
+import PersistFormData from '../common/PersistFormData'
 
 type LoginFormInputs = {
   title: string
@@ -93,6 +94,8 @@ export default function StoryForm() {
     >
       {(props) => (
         <Form>
+          <PersistFormData name="story-form" />
+
           {/* Anonymous */}
           <Field name="anonymous">
             {({ field, form }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12336,6 +12336,11 @@
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
       "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
     },
+    "use-debounce": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-6.0.1.tgz",
+      "integrity": "sha512-kpvIxpa0vOLz/2I2sfNJ72mUeaT2CMNCu5BT1f2HkV9qZK27UVSOFf1sSSu+wjJE4TcR2VTXS2SM569+m3TN7Q=="
+    },
     "use-sidecar": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
     "next-sitemap": "^1.6.25",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-fast-compare": "^3.2.0",
     "react-share": "^4.4.0",
     "sanitize-html": "^2.3.3",
     "superjson": "^1.7.4",
+    "use-debounce": "^6.0.1",
     "yup": "^0.32.9"
   },
   "devDependencies": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,9 +24,7 @@ const MainPage = ({ stories }: MainPageProps) => {
       <FloatingRibbon>
         <NextLink href="/new" passHref>
           <Link>
-            <Button my={"5px"}>
-              Add Your Story
-            </Button>
+            <Button my={'5px'}>Add Your Story</Button>
           </Link>
         </NextLink>
       </FloatingRibbon>

--- a/pages/story/[id].tsx
+++ b/pages/story/[id].tsx
@@ -100,7 +100,7 @@ export default function StoryPage(props: StoryPageProps): JSX.Element {
       </Box>
 
       <FloatingRibbon>
-        <Button onClick={onOpen} my={"5px"}>
+        <Button onClick={onOpen} my={'5px'}>
           Share This Story
         </Button>
 


### PR DESCRIPTION
### Persist form data

This change has been introduced to prevent someone from losing their story if their device suddenly crashes, as per @mwickett's suggestion in #29.

#### To do:
- [x] Clean form data after successful submission.

Closes #29.