### PR TITLE
close nav panel on route change

### DIFF
--- a/components/common/Nav.tsx
+++ b/components/common/Nav.tsx
@@ -1,4 +1,5 @@
-import { MouseEventHandler, useState } from 'react'
+import { MouseEventHandler, useState, useEffect, useCallback } from 'react'
+import Router from 'next/router'
 import {
   Box,
   Button,
@@ -128,6 +129,13 @@ export default function Nav({ ...props }: FlexProps & PositionProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   const toggle = (): void => setIsOpen(!isOpen)
+
+  const closePanel = useCallback(() => setIsOpen(false), [])
+
+  useEffect(() => {
+    Router.events.on('routeChangeComplete', closePanel)
+    return () => Router.events.off('routeChangeComplete', closePanel)
+  }, [closePanel])
 
   return (
     <NavBarContainer {...props}>

--- a/components/common/Nav.tsx
+++ b/components/common/Nav.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useState, useEffect, useCallback } from 'react'
+import { MouseEventHandler, useState, useEffect } from 'react'
 import Router from 'next/router'
 import {
   Box,
@@ -130,12 +130,11 @@ export default function Nav({ ...props }: FlexProps & PositionProps) {
 
   const toggle = (): void => setIsOpen(!isOpen)
 
-  const closePanel = useCallback(() => setIsOpen(false), [])
-
   useEffect(() => {
+    const closePanel = () => setIsOpen(false)
     Router.events.on('routeChangeComplete', closePanel)
     return () => Router.events.off('routeChangeComplete', closePanel)
-  }, [closePanel])
+  }, [])
 
   return (
     <NavBarContainer {...props}>


### PR DESCRIPTION
Listens to `next/router` events to close the nav panel on a route change. Makes browsing on mobile a bit smoother.﻿
