### PR TITLE
page size as argument

### DIFF
--- a/lib/api/stories.ts
+++ b/lib/api/stories.ts
@@ -30,14 +30,14 @@ function applySelect(story) {
 }
 
 // GET /api/stories
-export async function list(size: number = null) {
-  const takeSize = { take: size }
+export async function list(limit: number = null) {
+  const takeLimit = { take: limit }
   try {
     return await prisma.story.findMany({
       where: { approved: true },
       orderBy: { updatedAt: 'desc' },
       select,
-      ...(size && takeSize),
+      ...(limit && takeLimit),
     })
   } catch (err) {
     throw internalServerError()

--- a/lib/api/stories.ts
+++ b/lib/api/stories.ts
@@ -30,13 +30,14 @@ function applySelect(story) {
 }
 
 // GET /api/stories
-export async function list() {
+export async function list(size: number = null) {
+  const takeSize = { take: size }
   try {
     return await prisma.story.findMany({
-      take: 100,
       where: { approved: true },
       orderBy: { updatedAt: 'desc' },
       select,
+      ...(size && takeSize),
     })
   } catch (err) {
     throw internalServerError()


### PR DESCRIPTION
We were limiting out static pre-render to 100 stories because of the `take` specified in the Prisma query. This adds `size` as a parameter to `list()`, and if it's not passed means Prisma will return all records.