### PR TITLE
Use browser back on story close to restore scroll position in feed

### DIFF
--- a/components/stories/StoryDetail.tsx
+++ b/components/stories/StoryDetail.tsx
@@ -14,7 +14,6 @@ import Label from '../common/Label'
 
 import { ContentWarningBox } from '../common/Warnings'
 import ShareSVG from '../icons/ShareSVG'
-import SimpleLink from '../common/SimpleLink'
 
 function StoryParagraphs(p: string, i: number) {
   return <Text key={i}>{p}</Text>
@@ -22,10 +21,11 @@ function StoryParagraphs(p: string, i: number) {
 
 interface StoryDetailProps {
   story: Story
+  onClose: () => void
   onShare: () => void
 }
 
-export default function StoryDetail({ story, onShare }: StoryDetailProps) {
+export default function StoryDetail({ story, onClose, onShare }: StoryDetailProps) {
   return (
     <Box>
       <Box bgImage={`url(${storyImage(story)})`} bgSize="cover" bgPosition="center" color="white">
@@ -45,18 +45,16 @@ export default function StoryDetail({ story, onShare }: StoryDetailProps) {
                   icon={<ShareSVG />}
                   onClick={onShare}
                 />
-
-                <SimpleLink href="/">
-                  <IconButton
-                    size="md"
-                    mr={-2}
-                    py={2}
-                    variant="link"
-                    colorScheme="white"
-                    aria-label="Close"
-                    icon={<CloseIcon />}
-                  />
-                </SimpleLink>
+                <IconButton
+                  size="md"
+                  mr={-2}
+                  py={2}
+                  variant="link"
+                  colorScheme="white"
+                  aria-label="Close"
+                  icon={<CloseIcon />}
+                  onClick={onClose}
+                />
               </Flex>
             </Flex>
             <Heading

--- a/components/stories/StoryFeed.tsx
+++ b/components/stories/StoryFeed.tsx
@@ -33,7 +33,7 @@ function StorySummary({ story }: StorySummaryProps) {
 
   return (
     <Box as="article">
-      <NextLink href={href} passHref>
+      <NextLink href={`${href}?back=true`} as={href} passHref>
         <a style={{ textDecoration: 'none' }}>
           <Box
             borderRadius="8px"

--- a/pages/story/[id].tsx
+++ b/pages/story/[id].tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import {
   Box,
   Drawer,
@@ -51,6 +52,7 @@ const shareIconSize = 64
 const buttonStyle: CSSProperties = { marginRight: '12px', marginBottom: '12px' }
 
 export default function StoryPage(props: StoryPageProps): JSX.Element {
+  const router = useRouter()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const url = props.success ? `${process.env.BASE_URL}/story/${props.story.id}` : ''
   const { onCopy } = useClipboard(url)
@@ -66,6 +68,12 @@ export default function StoryPage(props: StoryPageProps): JSX.Element {
   }
 
   const { story } = props
+
+  // If we came from the feed, go back on cancel. If not, navigate forward to the feed.
+  // Going back in the browser history returns to the user's previous scroll position in the feed.
+  function handleClose(): void {
+    router.query.back === 'true' ? router.back() : router.push('/')
+  }
 
   function handleURLCopy() {
     onCopy()
@@ -86,7 +94,7 @@ export default function StoryPage(props: StoryPageProps): JSX.Element {
       <HeadTags title={story.title} description={story.content} previewImage={storyImage(story)} />
 
       <Box>
-        <StoryDetail story={story} onShare={onOpen} />
+        <StoryDetail story={story} onClose={handleClose} onShare={onOpen} />
       </Box>
 
       <FloatingRibbon>


### PR DESCRIPTION
This reverts part of @LuckeeDev's PR #139, which sought to improve accessibility by turning the Close button on the individual story page into a simple link to /.

While well intentioned, that change caused a problem: Going back restores the scroll position on the previous page, but navigating forward does not. So, readers now lose their position in the feed when they use the Close button to return to it. In general, implementing a Back or Close button by invoking the browser back behaviour is a good approach. In addition to the scroll position advantage, it usually reflects the user's intent, which results in a location history that's more useful and makes more sense to them.

As for the accessibility concern, I believe it's misplaced. The back behaviour is valuable to all users, so that's why we're using a button rather than a link. However someone interacts with the site, it appears as a button marked Close, and that's exactly what it is. There are already plain links to / elsewhere on the page, if that's what someone is looking for.

The other change in the PR, which made the story links keyboard accessible was an important improvement, so I'm leaving that part intact -- though I did need to put back the special href with `?back=true` that tells the story page that it's safe to go back (as opposed to if someone follows a link directly to a story from an external source).