### PR TITLE
Do not sanitize HTML in new stories to avoid entity references

### DIFF
--- a/lib/api/stories.ts
+++ b/lib/api/stories.ts
@@ -2,6 +2,7 @@ import { PrismaClientValidationError } from '@prisma/client/runtime'
 import { ValidationError } from 'yup'
 import prisma from '../prisma'
 import storySchema from '../storySchema'
+import { fixTitle } from '../model/story'
 import { badRequest, internalServerError, notFound } from '../errors'
 
 const select = {
@@ -64,6 +65,9 @@ export async function add(story: NewStory) {
     // Strip empty values
     if (story[k] === '') {
       return acc
+      // Clean up title
+    } else if (k === 'title') {
+      acc[k] = fixTitle(story[k])
       // Uppercase postal
     } else if (k === 'postal') {
       acc[k] = story[k].toUpperCase()

--- a/lib/api/stories.ts
+++ b/lib/api/stories.ts
@@ -1,4 +1,3 @@
-import sanitizeHtml from 'sanitize-html'
 import { PrismaClientValidationError } from '@prisma/client/runtime'
 import { ValidationError } from 'yup'
 import prisma from '../prisma'
@@ -68,9 +67,6 @@ export async function add(story: NewStory) {
       // Uppercase postal
     } else if (k === 'postal') {
       acc[k] = story[k].toUpperCase()
-      // Sanitize any strings
-    } else if (typeof story[k] === 'string') {
-      acc[k] = sanitizeHtml(story[k], { allowedTags: [], allowedAttributes: {} })
       // Don't forget the rest
     } else {
       acc[k] = story[k]

--- a/lib/model/story.test.ts
+++ b/lib/model/story.test.ts
@@ -1,0 +1,63 @@
+import { fixTitle } from './story'
+
+describe('fixTitle()', () => {
+  test('returns a clean title unchanged', () => {
+    const title = 'This is my story'
+    expect(fixTitle(title)).toBe(title)
+  })
+
+  test('trims whitespace from the beginning and end of the title', () => {
+    expect(fixTitle('  This is my story\n')).toBe('This is my story')
+  })
+
+  test('removes matched straight single quotes from around the title', () => {
+    expect(fixTitle("'This is my story'")).toBe('This is my story')
+  })
+
+  test('removes matched curly single quotes from around the title', () => {
+    expect(fixTitle('‘This is my story’')).toBe('This is my story')
+  })
+
+  test('removes matched straight double quotes from around the title', () => {
+    expect(fixTitle('"This is my story"')).toBe('This is my story')
+  })
+
+  test('removes matched curly double quotes from around the title', () => {
+    expect(fixTitle('“This is my story”')).toBe('This is my story')
+  })
+
+  test('removes matched quotes inside from around the title within trimmed whitespace', () => {
+    expect(fixTitle('  ‘This is my story’\t')).toBe('This is my story')
+  })
+
+  test('does not remove an unmatched quote from the start of the title', () => {
+    const title = "'Why,' I wonder."
+    expect(fixTitle(title)).toBe(title)
+  })
+
+  test('does not remove an unmatched quote from the end of the title', () => {
+    const title = 'I wonder, ‘why’?'
+    expect(fixTitle(title)).toBe(title)
+  })
+
+  test('removes matched quotes inside from around the title within trimmed whitespace', () => {
+    expect(fixTitle("  'This is my story’\t")).toBe('This is my story')
+  })
+
+  test('trims whitespace within removed quotes from around the title', () => {
+    expect(fixTitle('“ This is my story\n"')).toBe('This is my story')
+  })
+
+  test('converts all internal double quotes to the corresponding single quote', () => {
+    const expected = "‘Here,’ she said. 'Why?' I wondered."
+    expect(fixTitle('“Here,” she said. "Why?" I wondered.')).toBe(expected)
+  })
+
+  test('collapses each internal whitespace occurence to a single space', () => {
+    expect(fixTitle('This   is \nmy\tstory')).toBe('This is my story')
+  })
+
+  test('handles a title requiring multiple fixes', () => {
+    expect(fixTitle('\n\'"Why?" \r‘Why not?’  \'\n')).toBe("'Why?' ‘Why not?’")
+  })
+})

--- a/lib/model/story.ts
+++ b/lib/model/story.ts
@@ -1,0 +1,29 @@
+const QUOTES = {
+  single: '\u0027',
+  singleLeft: '\u2018',
+  singleRight: '\u2019',
+  double: '\u0022',
+  doubleLeft: '\u201C',
+  doubleRight: '\u201D',
+}
+
+const SINGLE_QUOTES = [QUOTES.single, QUOTES.singleLeft, QUOTES.singleRight]
+const DOUBLE_QUOTES = [QUOTES.double, QUOTES.doubleLeft, QUOTES.doubleRight]
+
+export function fixTitle(title = '') {
+  title = title.trim()
+  const first = title.charAt(0)
+  const last = title.charAt(title.length - 1)
+  if (
+    (SINGLE_QUOTES.includes(first) && SINGLE_QUOTES.includes(last)) ||
+    (DOUBLE_QUOTES.includes(first) && DOUBLE_QUOTES.includes(last))
+  ) {
+    title = title.substring(1, title.length - 1)
+  }
+  return title
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(new RegExp(QUOTES.double, 'g'), QUOTES.single)
+    .replace(new RegExp(QUOTES.doubleLeft, 'g'), QUOTES.singleLeft)
+    .replace(new RegExp(QUOTES.doubleRight, 'g'), QUOTES.singleRight)
+}


### PR DESCRIPTION
This addresses the issue of entity references (e.g. `&amp;`) in our stories by simply removing HTML sanitization from the handling of the POST /api/stories API. Since we've decided that we're treating stories as plain text and we're avoiding potential XSS at display time (by placing the content inside `<p>` elements in a React render, not using `dangerouslySetInnerHTML`), there's no need to do any sanitization here.

You could make a case for still stripping out HTML, but I think that's a much lower priority than fixing the current mishandling of & and <. Someone would actually have to type or copy HTML elements into a plain text box, which seems unlikely. If that  does happen, we could fix it manually.

Since we're now going to emailing story text to politicians automatically, we really should stop mangling them as quickly as possible.