### PR TITLE
Use riding info, if available, to email a story to the correct MPP

### DIFF
--- a/components/admin/StoryCard.tsx
+++ b/components/admin/StoryCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
   Box,
   Button,
@@ -10,9 +11,8 @@ import {
   Tooltip,
   useDisclosure,
 } from '@chakra-ui/react'
-import SimpleLink from '../common/SimpleLink'
-import { useState } from 'react'
 import { AdminStory, storyProvince } from '../../lib/model/story'
+import SimpleLink from '../common/SimpleLink'
 import { categoryLabel } from '../stories/utils'
 
 interface UpdateStoryProps {

--- a/components/admin/StoryCard.tsx
+++ b/components/admin/StoryCard.tsx
@@ -7,11 +7,12 @@ import {
   Stack,
   Text,
   TextProps,
+  Tooltip,
   useDisclosure,
 } from '@chakra-ui/react'
 import SimpleLink from '../common/SimpleLink'
 import { useState } from 'react'
-import { Story } from '@prisma/client'
+import { AdminStory, storyProvince } from '../../lib/model/story'
 import { categoryLabel } from '../stories/utils'
 
 interface UpdateStoryProps {
@@ -42,31 +43,31 @@ const Label = ({ children, ...props }: TextProps) => {
 }
 
 interface StoryCardProps {
-  story: Story
+  story: AdminStory
   filteredView: boolean
 }
 
-export default function StoryCard({
-  story: {
+export default function StoryCard({ story, filteredView }: StoryCardProps) {
+  const {
     id,
     createdAt,
     title,
     content,
-    displayName,
     postal,
+    postalCode,
+    displayName,
     email,
     phone,
     twitter,
     category,
     mppMessageId,
     ...rest
-  },
-  filteredView,
-}: StoryCardProps) {
+  } = story
+  const { name: location, hotspot, ridings } = postalCode ?? {}
+  const riding = ridings?.[0]?.riding
+
   const { isOpen, onOpen, onClose } = useDisclosure()
-
   const [{ deleted, approved, contentWarning }, setCardStatus] = useState({ ...rest })
-
   const [interacted, setInteracted] = useState(false)
 
   const handleDeleteInteraction = async (props) => {
@@ -107,11 +108,32 @@ export default function StoryCard({
             <Label>Display Name and Postal Code</Label>
             <Text>
               {displayName || `Anonymous`} from {postal}
+              {hotspot && (
+                <>
+                  {' '}
+                  <Tooltip hasArrow label="COVID-19 hotspot">
+                    <span role="img" aria-label="COVID-19 hotspot">
+                      🔥
+                    </span>
+                  </Tooltip>
+                </>
+              )}
+            </Text>
+          </Box>
+          <Box>
+            <Label>Location</Label>
+            <Text>
+              {location ? `${location}, ` : ''}
+              {storyProvince(story) || 'Unknown'}
             </Text>
           </Box>
           <Box>
             <Label>Consent to be Contacted</Label>
             <Text>{email || twitter || phone ? `Yes` : 'No'}</Text>
+          </Box>
+          <Box>
+            <Label>MPP and Riding</Label>
+            <Text>{riding ? `${riding.mppName}, ${riding.name}` : 'Unknown'}</Text>
           </Box>
           <Box>
             <Label>Submission Date</Label>

--- a/lib/emailer.ts
+++ b/lib/emailer.ts
@@ -3,9 +3,9 @@
 // To send emails in non-prod environments, you must set the MPP_EMAILS environment variable.
 // Its value is a comma-separated list of addresses to receive emails for testing purposes.
 
-import { Story } from '@prisma/client'
-import sanitize from 'sanitize-html'
 import mail from '@sendgrid/mail'
+import sanitize from 'sanitize-html'
+import { AdminStory, storyProvince } from './model/story'
 
 mail.setApiKey(process.env.SENDGRID_API_KEY)
 
@@ -15,7 +15,7 @@ const FROM_EMAIL = 'MyCovidStory.ca <info@mycovidstory.ca>'
 const BCC_EMAIL = process.env.VERCEL_ENV === 'production' ? 'info+mpp@mycovidstory.ca' : undefined
 
 // The default addresses to receive stories from Ontario.
-// When we have a specific MPP based on the postal code, these addresses will be cc'ed.
+// If we are emailing the MPP for a specific riding, these addresses will be cc'ed.
 const ONTARIO_EMAILS = [
   'premier@ontario.ca',
   'doug.fordco@pc.ola.org',
@@ -38,7 +38,7 @@ const CANADA_EMAILS = [
 const CANADA_ADDRESSEE = 'Prime Minster Trudeau, Minister Freeland, and Minister Hajdu'
 
 // Parse comma-separated list of email adress from MPP_EMAILS environment variable.
-// If specified, custom emails are always used as-is. No riding-based addresses are ever added.
+// If specified, custom emails are always used as-is, never modified based on riding.
 const CUSTOM_EMAILS = (() => {
   if (process.env.MPP_EMAILS) {
     return process.env.MPP_EMAILS.split(',')
@@ -69,7 +69,7 @@ const ENABLED = (() => {
 // Does not check if an email has already been sent for the story. The caller must do that.
 // If an email is sent successfully, returns the message ID or '-' if none can be determined.
 // Returns null if emailing is disabled or sending an email fails.
-export async function send(story: Story): Promise<string | null> {
+export async function send(story: AdminStory): Promise<string | null> {
   if (ENABLED) {
     console.log(`Sending email for story ${story.id}`)
     const message = createMessage(story)
@@ -85,44 +85,84 @@ export async function send(story: Story): Promise<string | null> {
   return null
 }
 
-function createMessage({ postal, id, title, content }: Story) {
-  const ontario = isOntario(postal)
-  const to = CUSTOM_EMAILS || (ontario ? ONTARIO_EMAILS : CANADA_EMAILS)
-  const subject = `A COVID-19 story${ontario ? ' from Ontario' : ''}`
-  const addressee = ontario ? ONTARIO_ADDRESSEE : CANADA_ADDRESSEE
-  const jurisdiction = ontario ? 'Ontario' : 'Canada'
-  const url = `${process.env.BASE_URL}/story/${id}`
-  const params = { addressee, postal, jurisdiction, url, title, content }
+function createMessage(story: AdminStory) {
+  const {
+    fields: { to, cc, ...fields },
+    params,
+  } = computeDetails(story)
+
+  // If custom emails are specified, they always override the recipients, and there is no cc.
   return {
-    from: FROM_EMAIL,
-    to,
-    bcc: BCC_EMAIL,
-    subject,
+    to: CUSTOM_EMAILS || to,
+    cc: CUSTOM_EMAILS ? undefined : cc,
+    ...fields,
     text: generateText(params),
     html: generateHtml(params),
   }
 }
 
-function isOntario(postal: string) {
-  // Postal codes are uppercased in stories.add().
-  return ['K', 'L', 'M', 'N', 'P'].includes(postal.charAt(0))
+function computeDetails(story: AdminStory) {
+  const from = FROM_EMAIL
+  const bcc = BCC_EMAIL
+  const ontario = storyProvince(story) === 'ON'
+  const emails = ontario ? ONTARIO_EMAILS : CANADA_EMAILS
+  const subject = 'A COVID-19 story'
+
+  const { id, title, content, postal, postalCode } = story
+  const url = `${process.env.BASE_URL}/story/${id}`
+  const params = { url, title, content }
+  const riding = postalCode?.ridings?.[0]?.riding
+
+  if (riding) {
+    const { name: ridingName, mppEmail, mppDesignation, mppLastName } = riding
+    return {
+      fields: { from, to: mppEmail, cc: emails, bcc, subject: `${subject} from ${ridingName}` },
+      params: {
+        addressee: `${mppDesignation} ${mppLastName}`,
+        source: 'by one of your constituents',
+        location: 'in your very own riding',
+        ...params,
+      },
+    }
+  }
+
+  if (ontario) {
+    return {
+      fields: { from, to: emails, bcc, subject: `${subject} from Ontario` },
+      params: {
+        addressee: ONTARIO_ADDRESSEE,
+        source: `from ${postalCode ? postalCode.name : `postal code ${postal}`}`,
+        location: 'in Ontario, right now',
+        ...params,
+      },
+    }
+  }
+
+  const source = postalCode
+    ? `from ${postalCode.name}, ${postalCode.province}`
+    : `from postal code ${postal}`
+
+  return {
+    fields: { from, to: emails, bcc, subject },
+    params: { addressee: CANADA_ADDRESSEE, source, location: 'in Canada, right now', ...params },
+  }
 }
 
 interface BodyParams {
   addressee: string
-  postal: string
-  jurisdiction: string
+  source: string
+  location: string
   url: string
   title: string
   content: string
 }
 
-function generateText({ addressee, postal, jurisdiction, url, title, content }: BodyParams) {
+function generateText({ addressee, source, location, url, title, content }: BodyParams) {
   return `Hello ${addressee},
 
 MyCovidStory.ca is a volunteer-led effort to collect and amplify the stories of those impacted by COVID-19. We believe in the power of storytelling and that because the government has refused to listen to the numbers, we must make them face the stories of the people they were elected to represent.
 
-The following story was submitted from postal code ${postal}:
+The following story was submitted ${source}:
 
 "${title}"
 
@@ -130,7 +170,7 @@ ${content}
 
 ${url}
 
-Every number has a story, and this is a story happening in ${jurisdiction}, right now.
+Every number has a story, and this is a story happening ${location}.
 
 We encourage you to visit www.mycovidstory.ca to read more of these stories and to use your power to advance effective government policy that will actually save lives.
 
@@ -148,13 +188,13 @@ Instagram: https://www.instagram.com/mycovidstory_ca/
 
 const SANITIZE_OPTIONS = { allowedTags: [], allowedAttributes: {} }
 
-function generateHtml({ addressee, postal, jurisdiction, url, title, content }: BodyParams) {
+function generateHtml({ addressee, source, location, url, title, content }: BodyParams) {
   title = sanitize(title, SANITIZE_OPTIONS)
   content = sanitize(content, SANITIZE_OPTIONS)
 
   return `<p>Hello ${addressee},</p>
 <p>MyCovidStory.ca is a volunteer-led effort to collect and amplify the stories of those impacted by COVID-19. We believe in the power of storytelling and that because the government has refused to listen to the numbers, we must make them face the stories of the people they were elected to represent.</p>
-<p>The following story was submitted from postal code ${postal}:</p>
+<p>The following story was submitted ${source}:</p>
 <div style="background: #f9f9f9; border-left: 0.5em solid #ccc; margin: 2em 0; padding: 1px 1em;">
 <p><a href="${url}" style="color: inherit; text-decoration: none;"><strong>“${title}”</strong></a></p>
 ${content
@@ -164,7 +204,7 @@ ${content
   .map((p) => `<p><a href="${url}" style="color: inherit; text-decoration: none;">${p}</a></p>`)
   .join('\n')}
 </div>
-<p>Every number has a story, and <strong>this is a story happening in ${jurisdiction}, right now.</strong></p>
+<p>Every number has a story, and <strong>this is a story happening ${location}.</strong></p>
 <p>We encourage you to visit <a href="https://www.mycovidstory.ca">www.mycovidstory.ca</a> to read more of these stories and to use your power to advance effective government policy that will actually save lives.</p>
 <p>Thank you,</p>
 <p>The MyCovidStory.ca Team</p>

--- a/lib/model/story.test.ts
+++ b/lib/model/story.test.ts
@@ -1,4 +1,4 @@
-import { testStory, fixTitle } from './story'
+import { testStory, storyProvince, fixTitle } from './story'
 
 describe('testStory()', () => {
   test('creates a story for testing with basic required properties', () => {
@@ -16,6 +16,63 @@ describe('testStory()', () => {
     const story = testStory({ title: 'My title', content: 'This is the content of my story.' })
     expect(story).toHaveProperty('title', 'My title')
     expect(story).toHaveProperty('content', 'This is the content of my story.')
+  })
+})
+
+describe('storyProvince()', () => {
+  test("determines the province from the first letter of the story's postal code", () => {
+    const story = testStory({ postal: 'V6B' })
+    expect(storyProvince(story)).toBe('BC')
+  })
+
+  test('determines the province in spite of an invalid third digit', () => {
+    const story = testStory({ postal: 'H1D' })
+    expect(storyProvince(story)).toBe('QC')
+  })
+
+  test('correctly identifies all five first letters for Ontario', () => {
+    expect(storyProvince(testStory({ postal: 'K1A' }))).toBe('ON')
+    expect(storyProvince(testStory({ postal: 'L1A' }))).toBe('ON')
+    expect(storyProvince(testStory({ postal: 'M1A' }))).toBe('ON')
+    expect(storyProvince(testStory({ postal: 'N1A' }))).toBe('ON')
+    expect(storyProvince(testStory({ postal: 'P1A' }))).toBe('ON')
+  })
+
+  test('correctly identifies one of the specific Nunavut X postal codes', () => {
+    const story = testStory({ postal: 'X0B' })
+    expect(storyProvince(story)).toBe('NU')
+  })
+
+  test('indentifies other X postal codes as Northwest Territories', () => {
+    const story = testStory({ postal: 'X1A' })
+    expect(storyProvince(story)).toBe('NT')
+  })
+
+  test("return undefined if the first letter of the story's postal code is invalid", () => {
+    const story = testStory({ postal: 'F4C' })
+    expect(storyProvince(story)).toBeUndefined()
+  })
+
+  test('correctly handles a postal code that is not uppercase', () => {
+    const story = testStory({ postal: 'm5v' })
+    expect(storyProvince(story)).toBe('ON')
+  })
+
+  test('correctly handles a full postal code', () => {
+    const story = testStory({ postal: 'X0B 1B0' })
+    expect(storyProvince(story)).toBe('NU')
+  })
+
+  test('returns the province from a known postal code instead of determining it again', () => {
+    const postalCode = {
+      code: 'M5V',
+      province: 'OO',
+      type: 'urban',
+      hotspot: true,
+      name: 'Somewhere Else',
+    }
+    const story = testStory({ postal: 'M5V', postalCode })
+    expect(storyProvince(story)).toBe('OO')
   })
 })
 

--- a/lib/model/story.ts
+++ b/lib/model/story.ts
@@ -38,6 +38,37 @@ export function testStory(overrides = {}): Story {
   return { ...BASE_TEST_STORY, ...overrides }
 }
 
+// Nunavut/Northwest Territories share a first letter, so a function is needed to disambiguate.
+const POSTAL_PROVINCE = {
+  A: 'NL',
+  B: 'NS',
+  C: 'PE',
+  E: 'NB',
+  G: 'QC',
+  H: 'QC',
+  J: 'QC',
+  K: 'ON',
+  L: 'ON',
+  M: 'ON',
+  N: 'ON',
+  P: 'ON',
+  R: 'MB',
+  S: 'SK',
+  T: 'AB',
+  V: 'BC',
+  X: (postal) => (['X0A', 'X0B', 'X0C'].includes(postal) ? 'NU' : 'NT'),
+  Y: 'YT',
+}
+
+export function storyProvince({ postal, postalCode }: Story): string | undefined {
+  postal = postal.substring(0, 3).toUpperCase()
+  if (postalCode) {
+    return postalCode.province
+  }
+  const province = POSTAL_PROVINCE[postal.charAt(0)]
+  return typeof province === 'function' ? province(postal) : province
+}
+
 const QUOTES = {
   single: '\u0027',
   singleLeft: '\u2018',
@@ -67,3 +98,17 @@ export function fixTitle(title = '') {
     .replace(new RegExp(QUOTES.doubleLeft, 'g'), QUOTES.singleLeft)
     .replace(new RegExp(QUOTES.doubleRight, 'g'), QUOTES.singleRight)
 }
+
+export const ADMIN_INCLUDE = {
+  postalCode: {
+    include: {
+      ridings: {
+        include: {
+          riding: true,
+        },
+      },
+    },
+  },
+}
+
+export type AdminStory = Prisma.StoryGetPayload<{ include: typeof ADMIN_INCLUDE }>

--- a/pages/_admin/index.tsx
+++ b/pages/_admin/index.tsx
@@ -3,14 +3,14 @@ import { getSession, useSession } from 'next-auth/client'
 import HeadTags from '../../components/common/HeadTags'
 
 import prisma from '../../lib/prisma'
-import { Story } from '@prisma/client'
+import { ADMIN_INCLUDE, AdminStory } from '../../lib/model/story'
 import ContentBox from '../../components/common/ContentBox'
 import { GetServerSidePropsContext } from 'next'
 import AdminLayout from '../../layouts/Admin'
 import StoryCard from '../../components/admin/StoryCard'
 
 interface _Admin {
-  stories: Story[] | []
+  stories: AdminStory[] | []
   filtered: boolean
 }
 
@@ -38,7 +38,6 @@ const _Admin = ({ stories, filtered }: _Admin) => {
 }
 
 _Admin.setLayout = AdminLayout
-
 export default _Admin
 
 export async function getServerSideProps({ req, query }: GetServerSidePropsContext) {
@@ -47,7 +46,7 @@ export async function getServerSideProps({ req, query }: GetServerSidePropsConte
   const deleted = query.deleted === 'true'
   const approved = query.approved === 'true'
 
-  let stories = {}
+  let stories = []
   if (session) {
     stories = await prisma.story.findMany({
       where: {
@@ -55,6 +54,7 @@ export async function getServerSideProps({ req, query }: GetServerSidePropsConte
         deleted,
       },
       orderBy: { createdAt: 'asc' },
+      include: ADMIN_INCLUDE,
     })
   }
 

--- a/pages/_admin/index.tsx
+++ b/pages/_admin/index.tsx
@@ -1,20 +1,19 @@
-import { Stack } from '@chakra-ui/react'
+import { GetServerSidePropsContext } from 'next'
 import { getSession, useSession } from 'next-auth/client'
-import HeadTags from '../../components/common/HeadTags'
-
+import { Stack } from '@chakra-ui/react'
 import prisma from '../../lib/prisma'
 import { ADMIN_INCLUDE, AdminStory } from '../../lib/model/story'
-import ContentBox from '../../components/common/ContentBox'
-import { GetServerSidePropsContext } from 'next'
 import AdminLayout from '../../layouts/Admin'
+import HeadTags from '../../components/common/HeadTags'
+import ContentBox from '../../components/common/ContentBox'
 import StoryCard from '../../components/admin/StoryCard'
 
-interface _Admin {
+interface AdminPageProps {
   stories: AdminStory[] | []
   filtered: boolean
 }
 
-const _Admin = ({ stories, filtered }: _Admin) => {
+function AdminPage({ stories, filtered }: AdminPageProps) {
   const [session] = useSession()
 
   return (
@@ -37,8 +36,8 @@ const _Admin = ({ stories, filtered }: _Admin) => {
   )
 }
 
-_Admin.setLayout = AdminLayout
-export default _Admin
+AdminPage.setLayout = AdminLayout
+export default AdminPage
 
 export async function getServerSideProps({ req, query }: GetServerSidePropsContext) {
   const session = await getSession({ req })

--- a/pages/api/admin/update.ts
+++ b/pages/api/admin/update.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getSession } from 'next-auth/client'
-import { Story } from '@prisma/client'
+import { ADMIN_INCLUDE, AdminStory } from '../../../lib/model/story'
 import prisma from '../../../lib/prisma'
 import { internalServerError, methodNotAllowed, sendError, unauthorized } from '../../../lib/errors'
 import * as emailer from '../../../lib/emailer'
@@ -23,8 +23,7 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse) 
 }
 
 // PATCH /api/admin/update
-// Required fields in body: id, approved
-// Updates Story.approved to value
+// Updates approved, deleted, contentWarning on the story with the given id.
 async function handlePatch(req: NextApiRequest, res: NextApiResponse) {
   const { id, approved, deleted, contentWarning } = req.body
 
@@ -36,6 +35,7 @@ async function handlePatch(req: NextApiRequest, res: NextApiResponse) {
         deleted,
         contentWarning,
       },
+      include: ADMIN_INCLUDE,
     })
 
     res.json(story)
@@ -49,7 +49,7 @@ async function handlePatch(req: NextApiRequest, res: NextApiResponse) {
 }
 
 // Emails the story to elected representatives if it is approved and has not already been emailed.
-async function emailStory(story: Story) {
+async function emailStory(story: AdminStory) {
   const { id } = story
 
   try {


### PR DESCRIPTION
This PR implements issue #92, completing the work involving postal code data.

For stories that can be mapped to a riding via postal code FSA (in Ontario only), they will be emailed to the correct MPP, with the default recipients (the Premier, Health Minister, etc.) on CC. A bit of the language in the email is also tweaked as per the [template](https://docs.google.com/document/d/1Gt6Gs6d6Fk_8BwOZI96yo9-VvCcQaTazCdPl3FtcUcA/edit?usp=sharing).

If available, the location, riding, and MPP are also shown for each story in the admin console, and hotspot postal codes are indicated by a fire emoji.